### PR TITLE
Fix license specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pydecorate
 
 Home: https://github.com/pytroll/pydecorate
 
-Package license: GPL-3.0-only
+Package license: GPL-3.0-or-later
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5110be42f0f2a58e2b1ea22ac6838b47f021402cf79fa0ec911ce7fb4243e54d
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv '
 
@@ -33,7 +33,7 @@ test:
 
 about:
   home: https://github.com/pytroll/pydecorate
-  license: GPL-3.0-only
+  license: GPL-3.0-or-later
   license_family: GPL3
   license_file: LICENSE.txt
   summary: 'Decorating PIL images: logos, texts, pallettes'


### PR DESCRIPTION
I misread the license and thought it was stricly GPL 3.0, but it is the "or later" variant.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
